### PR TITLE
Convert Markdown to HTML and force "dir" attribute to "rtl" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,240 +1,269 @@
-# لینک‌های ایرانی توسعه و طراحی
+<div class="expandable unchanged js-expandable rich-diff-level-zero">
+<h1 class="" dir="rtl">
+لینک‌های ایرانی توسعه و طراحی</h1>
+<p class="" dir="rtl">خواهشمند است لینک‌های <strong class="" dir="rtl">ایرانی</strong> درزمینه توسعه و طراحی را که می‌شناسید برای استفاده عموم به این صفحه اضافه نمایید.</p>
+<ul class="" dir="rtl">
+<li class="" dir="rtl">
+<a href="/rastikerdar/awesome-persian/blob/master/README.md#%D9%84%DB%8C%D9%86%DA%A9%D9%87%D8%A7%DB%8C-%D8%A7%DB%8C%D8%B1%D8%A7%D9%86%DB%8C-%D8%AA%D9%88%D8%B3%D8%B9%D9%87-%D9%88-%D8%B7%D8%B1%D8%A7%D8%AD%DB%8C" class="" dir="rtl">لینک‌های ایرانی توسعه و طراحی</a>
 
-خواهشمند است لینک‌های **ایرانی** درزمینه توسعه و طراحی را که می‌شناسید برای استفاده عموم به این صفحه اضافه نمایید.
-
-* [لینک‌های ایرانی توسعه و طراحی](#لینکهای-ایرانی-توسعه-و-طراحی)
-  * [پایتون](#پایتون-python)
-  * [جاوااسکریپت](#جاواسکریپت-javascript)
-  * [پی اچ پی](#پی-اچ-پی-php)
-  * [روبی](#روبی-ruby)
-  * [جاوا](#جاوا-java)
-  * [گو](#گو-go)
-  * [اندروید](#اندروید-android)
-  * [سی پلاس پلاس](#سی-پلاس-پلاس-c)
-  * [گنو/لینوکس](#گنولینوکس-gnulinux)
-  * [فونت](#فونت)
-  * [قالب](#قالب)
-  * [گروه‌ها](#گروه‌ها)
-  * [آموزشی](#آموزشی)
-  * [ادیتور](#ادیتور)
-  * [سایر](#سایر)
-
-## پایتون Python
-
-* [PlainTasks - پلاگین todo-list برای ویرایشگر sublime](https://github.com/aziz/PlainTasks)
-* [PyGlossary - کامل‌ترین ابزار تبدیل فایل‌های دیکشنری (گلاسری) با فرمت‌های مختلف](https://github.com/ilius/pyglossary)
-* [Hazm - کتابخانه پردازش زبان فارسی هضم در پایتون](https://github.com/sobhe/hazm/)
-* [StarCalendar - تقویم گرافیکی دوزبانه با پشتیبانی از هجری شمسی، میلادی و قمری](https://github.com/ilius/starcal/)
-* [Persian-Spell-checker - غلط‌یاب فارسی](https://github.com/reza1615/Persian-Spell-checker)
-* [jdatetime - کتابخانه تبدیل تاریخ جلالی میلادی در پایتون](https://github.com/slashmili/python-jalali)
-* [Persian.py - کتابخانه‌ای برای زبان فارسی در پایتون](https://github.com/itmard/persian.py)
-* [Khayyam - کتابخانه تبدیل تاریخ جلالی میلادی خیام در پایتون](https://github.com/pylover/khayyam)
-* [Lilak - دیکشنری غلط‌یاب فارسی](https://github.com/m-o-s-t-a-f-a/lilak)
-* [srtmerger - یه پروژه فان برای ترکیب کردن زیرنویس های ویدویی](https://github.com/iraj-jelo/srtmerger)
-* [parsnevesht - رفع خودکار برخی اشتباهات رایج در متون فارسی](https://github.com/maryayi/parsnevesht)
-* [wikitextparser - wikitext یک ابزار پایتونی تجزیه‌کننده](https://github.com/5j9/wikitextparser)
-* [pep8-per - آموزش Python PEP8 به زبان آدمیزاد](https://github.com/vahit/pep8-per)
-* [number2farsiword - تبدیل عدد به واژه‌فارسی](https://github.com/5j9/number2farsiword)
-* [telegram-iranbot - یک بات ساده برای تلگرام با کارکرد ترجمه انگلیسی به فارسی](https://github.com/mamal72/telegram-iranbot)
-* [SubtitleFixer - ترمیم زیرنویس‌های فارسی](https://github.com/aliva/SubtitleFixer)
-* [Honeybee - هانی‌بی - پلاگین گرس‌هاپر برای اتصال به اوپن‌استودیو، ریدینس، انرژی‌پلاس و دیزیم](https://github.com/mostaphaRoudsari/Honeybee)
-* [honeybeex - هانی‌بی‌اکس برای گرس ‌هاپر و داینامو ](https://github.com/ladybug-analysis-tools/honeybeex)
-* [ladybug - لیدی‌باگ - برای طراحی فضاهای اینوایرنمنتال در گرسهاپر](https://github.com/mostaphaRoudsari/ladybug)
-* [ladybug-dynamo - لیدی‌باگ برای داینامو](https://github.com/ladybug-analysis-tools/ladybug-dynamo)
-* [hydra-grasshopper - هیدار برای گرس هاپر](https://github.com/HydraShare/hydra-grasshopper)
-* [fonttools - کتابخانه ای برای ویرایش فونت ها در پایتون](https://github.com/behdad/fonttools)
-
-## جاواسکریپت Javascript
-
-* [persian.js - کتابخانه‌ای برای زبان فارسی در جاوااسکرپیت](https://github.com/usablica/persian.js)
-* [rial.js - کتابخانه‌ای برای فرمت نرخ و پول در جاوااسکریپت](https://github.com/habibpour/rial.js)
-* [sentence-info - نمایش اطلاعات نگارشی جمله فارسی](https://github.com/nainemom/sentence-info)
-* [کتابخانه تصحیح ورود عدد فارسی در جاوااسکریپت jquery](https://github.com/arashmilani/PersianDocumentNumberInputFix)
-* [tmTheme-Editor - ویرایشگر طرح رنگ برای editorها](http://tmtheme-editor.herokuapp.com/)
-* [PersianOcr - تشخیص کامپیوتری متن‌های نوشته‌شده به زبان فارسی](https://github.com/reza1615/PersianOcr)
-* [simple-html5-game - یک بازی ساده HTML5](https://github.com/habibpour/simple-html5-game)
-* [Persian-Calendar-for-Gnome-Shell - تاریخ/تقویم فارسی برای گنوم](https://github.com/omid/Persian-Calendar-for-Gnome-Shell)
-* [SaaghiBot - بات اشعار خیام برای تلگرام](https://github.com/mehdisadeghi/SaaghiBot)
-* [angular-persian - ابزارهای فارسی برای آنگولار](https://github.com/mohebifar/angular-persian)
-* [lebab - تبدیل کد ES5 به ES6](https://github.com/mohebifar/lebab)
-* [PersianDate - سیستم parsing, validating, manipulating و formatting تاریخ فارسی](https://github.com/babakhani/PersianDate)
-* [pwt.datepicker - ابزار انتخاب‌گر تاریخ](https://github.com/babakhani/pwt.datepicker)
-* [Angular Bootstrap Persian Datepicker - تقویم شمسی آنگولار](https://github.com/AminRahimi/angular-bootstrap-persian-datepicker)
-* [Twitter Bootstrap Jalali Datepicker - تقویم شمسی برای توییتر بوت استرپ](https://github.com/mousavian/bootstrap-jalali-datepicker)
-* [moratab - تسهیل ویرایش متون markdown](https://github.com/sobhe/moratab)
-* [moujez - خلاصه‌سازی متن](https://github.com/kharazi/moujez)
-* [nbpersian - کتاب Node.js برای مبتدی‌ها](https://github.com/imasood/nbpersian)
-* [chemozart - مدل‌ساز و ویرایشگر سه بعدی مولکولی مبتنی بر وب](https://github.com/mohebifar/chemozart)
-* [telegram-github-search-bot - بات جستجوی گیت‌هاب برای تلگرام](https://github.com/mamal72/telegram-github-search-bot)
-* [react-persian - مجموعه‌ای از کامپوننت های React برای زبان فارسی](https://github.com/mohebifar/react-persian)
-* [react-persian-datepicker - انتخابگر تاریخ فارسی برای React](https://github.com/mohebifar/react-persian-datepicker)
-* [react-github - یک مجموعه از کامپوننت های React برای گیت‌هاب](https://github.com/mamal72/react-github)
-* [electron-jalali-calendar - منوبار تقویم جلالی ساخته‌شده با Electron و React](https://github.com/mamal72/electron-jalali-calendar)
-* [jalaali-js - تبدیل تاریخ شمسی به میلادی و بالعکس](https://github.com/jalaali/jalaali-js)
-* [Iran - Administrative divisions of Iran in json and xml formats - تقسیمات کشوری ایران با فرمت جی‌سان و ایکس ام ال](https://github.com/arastu/iran)
-* [epwmap - ای‌پی‌دابلیو مپ - نقشه فایل های آب و هوای وزارت انرژی آمریکا بر روی نقشه جهان](https://github.com/mostaphaRoudsari/epwmap)
-* [SettlementEmerge - ستلمنت‌امرج - نقشه ای برای تصمیم گیری در جهت احداث های زیست محیطی](https://github.com/mostaphaRoudsari/SettlementEmerge)
-* [Virastar - نوشته‌های فارسی شما را ویرایش می‌کند](https://github.com/juvee/virastar/)
-* [fullcalendar - تقویم تمام صفحه برای مدیریت رویداده‌ها با کشیدن و رهاکردن](https://github.com/ehsandanesh/fullcalendar/)
-
-## پی اچ پی PHP
-
-* [jDateTime - کتابخانه تبدیل تاریخ جلالی میلادی در php](https://github.com/sallar/jDateTime)
-* [jalali - تسهیل کار با تاریخ ایرانی شمسی جلالی در برنامه های لاراول 5](https://github.com/morilog/jalali)
-* [payment-gateways - بسته پردازش درگاه برای سیستم شتاب ایران](https://github.com/laratalks/payment-gateways)
-* [پکیج کار با درگاههای بانکی](https://github.com/PoolPort/PoolPort)
-* [popcorn - یک API برای دریافت اطلاعات فیلم و سریال](https://github.com/iazami/popcorn)
-
-## روبی Ruby
-
-* [jalalidate - کتابخانه تبدیل تاریخ جلالی میلادی در روبی](https://github.com/aziz/jalalidate)
-* [openstudio-standards - مبحث‌۱۹ در اپن استودیو - استاندارد های انرژی ایران برای اوپن‌استودیو](https://github.com/BHRC/openstudio-standards)
-* [erect - ارکت - نانو بیلد سیستم](https://github.com/pmkary/erect)
-
-
-## جاوا Java
-
-* [PersianDT - کتابخانه تاریخ شمسی](https://github.com/abbashosseini/PersianDT)
-* [GraphLab - گرافلب شریف - استودیو تئوری گراف](https://github.com/azinazadi/GraphLab)
-
-## گو GO
-
-* [srtfixer - ترمیم زیرنویس‌های فارسی](https://github.com/sijad/srtfixer)
-
-## اندروید Android
-
-* [DroidPersianCalendar - برنامه تقویم فارسی اندروید](https://github.com/ebraminio/DroidPersianCalendar)
-* [PersianDatePicker - کتابخانه انتخاب‌گر تاریخ فارسی](https://github.com/alibehzadian/PersianDatePicker)
-* [TehranBrt - برنامه نمایش مسیرها و ایستگاه‌های بی آر تی تهران](https://github.com/MasoodFallahpoor/TehranBrt)
-* [InfoCenter - برنامه نمایش اطلاعات سخت‌افزاری گوشی/تبلت اندرویدی](https://github.com/MasoodFallahpoor/InfoCenter)
-* [PersianMaterialDateTimePicker - کتابخانه انتخاب‌گر تاریخ فارسی](https://github.com/mohamad-amin/PersianMaterialDateTimePicker)
-* [SunDatePicker - کتابخانه انتخاب‌گر تاریخ فارسی](https://github.com/alirezaafkar/SunDatePicker)
-* [Persian poem application - مجموعهٔ شعر فارسی](https://github.com/NileGroup/Meikade)
-* [farsitel - فارسیتل - اندروید فارسی](https://github.com/farsitel/)
-
-## سی پلاس پلاس C++
-
-* [Dana - ابزاری برای توسعه دانش به روش یادگیری Spaced Repetition](https://github.com/m-o-s-t-a-f-a/dana)
-* [Butterfly - باترفلای - کانکشن گرسه‌هاپر به اوپن‌فوم](https://github.com/mostaphaRoudsari/Butterfly)
-* [tracy - تریسی - موتور گرافیک سه بعدی](https://github.com/keyvank/tracy)
-* [harfbuzz - کتابخانه text shaping](https://github.com/behdad/harfbuzz)
-
-
-## سی شارپ C#
-* [hydra-dynamo - هیدار داینامو - برای انتشار مدل های داینامو در وب](https://github.com/HydraShare/hydra-dynamo)
-* [pablo - پابلو - موتور صفحه بندی و لیات ](https://github.com/pabloengine/pablo)
-* [framework-base - فریمورک کاری - فریم ورک ویرایش، قالب بندی و شکل دهی به متون](https://github.com/karyfoundation/framework-base)
-* [intactus - اینتکتوس - کتابخانه تولید نوتیشن ریاضی و چارت با استفاده از متن](https://github.com/karyfoundation/intactus)
-* [i3dml - آی‌تری‌دی‌ام - تریسی در دات نت](https://github.com/keyvank/i3dml)
-* [BD2 - بی‌دی‌۲ - موتور دیتابیس توضیع شده](https://github.com/Behrooz-Amoozad/BD2)
-* [numerica - نومریکا - تایپ عددی با ظرفیت دلخواه](https://github.com/karyfoundation/numerica)
-* [calculat -  NCalcکلکولات - نسخه بهتر شده کتابخانه](https://github.com/karyfoundation/calculat)
-* [series - سریز - یک بازی ترمینالی برای حدث زدن فرمول دنباله ها](https://github.com/pmkary/series)
-* [loc - لک - خط شمار تحت فریمورک کاری](https://github.com/pmkary/loc)
-* [note - نوت - برنامه یاداشت تحت فریمورک کاری](https://github.com/pmkary/note)
-* [equer - ایکوئر: تبدیل کننده فرمول به اسکریپت](https://github.com/pmkary/equer)
-* [textfliper -  تکست فیلپر - برای دوباره فارسی کردن نوشته های کپی شده از پی دی اف های ادوبی ](https://github.com/pmkary/textfliper)
-* [binominor - بینومینال - گسترش دهنده بسته نیوتونی](https://github.com/pmkary/binominor)
-* [PersianNumericConverter - مبدل عدد به متن فارسی و برعکس](https://github.com/RDF-Co/PersianNumericConverter)
-* [Bois - Binary Object Serializer تبدیل آبجکت ها به باینری فشرده](https://github.com/salarcode/Bois)
-
-## آبجکتیو-سی Objective-C
-* [Uninstaller - آن‌اینستالر - برنامه ای برای مدیریت برنامه های مک](https://github.com/kkiani/Uninstaller)
-
-## اپل‌اسکریپت AppleScript
-* [osx-term-icon - آیکون برای برنامه های شل](https://github.com/pmkary/osx-term-icon)
-
-## تایپ اسکریپت TypeScript
-* [comment - کامنت - جنریتور کامنت های کی-اف-سی-اس](https://github.com/karyfoundation/comment)
-* [V - وی - ابزاری برای تنظیم ارتفاع دیو های یک ردیف](https://github.com/pmkary/V)
-* [react-mixout - میکس آوت - میکیسنگ با اولویت بالاتر](https://github.com/alitaheri/react-mixout)
-* [isomorphic-vm - ایزومورفیک وی ام - دسترسی به نود جی اس از مرورگر](https://github.com/alitaheri/isomorphic-vm)
-* [react-stated - ری‌اکت استیتد - برای انتقال منطق کامپوننت ها به بیرون آن ها](https://github.com/alitaheri/react-stated)
-* [react-warpgate - ری‌اکت رپ‌گیت - ابزاری برای پیمایش اثربری ری‌اکت](https://github.com/alitaheri/react-warpgate)
-* [react-memo - ری‌اکت ممو](https://github.com/alitaheri/react-memo)
-
-## ارندل arendelle
-* [marker.js - مارکر.جی‌اس - هایلایتر وب ارندل](https://github.com/arendelle/marker.js)
-* [marker.js - مارکر.جی‌اس - هایلایتر وب ارندل](https://github.com/arendelle/marker.js)
-* [kai - کای‌ - پکج ارندل برای اتم](https://github.com/arendelle/kai)
-* [arendelle-js-core - کامپایلر ارندل به جاوا اسکریپت برای ارندل ۳](https://github.com/sinabakh/arendelle-js-core)
-* [gerda - جردا - اینتلی سنس برای ارندل](https://github.com/arendelle/gerda)
-* [sketchup-grid-importer - ایمپورتر گرید ارندل برای اسکپ‌آپ](https://github.com/arendelle/sketchup-grid-importer)
-* [arcco - آرکو - داکیومنشن جنریتور ارندل](https://github.com/arendelle/arcco)
-* [arcade - آرکید - اینترپرتر ارندل تا نسخه ۱.۶](https://github.com/arendelle/arcade)
-* [cliff - کلیف - فرمتر کد ارندل](https://github.com/arendelle/cliff)
-* [gothi - گاثی - تولید کننده متن برای ارندل](https://github.com/arendelle/gothi)
-* [marker - مارکر - هایلایتر وب ارندل](https://github.com/arendelle/marker)
-* [sitron - سیترون - مفسر ارندل ۲.۱۴](https://github.com/arendelle/sitron)
-* [book - کتاب زبان ارندل](https://github.com/arendelle/book)
-* [swifty - سویفتی - مفسر سویفت ۲.۱۴](https://github.com/arendelle/swifty)
-
-## گنو/لینوکس GNU/Linux
-
-* [linuxandlife - کتاب راهنمای لینوکس و زندگی](https://github.com/jadijadi/linuxandlife)
-* [راهنمای شِل اسکریپتینگ (برنامه‌نویسی خط فرمان لینوکس)](http://wiki.linuxreview.ir/Shell-scripting-tutorial)
-* [Jalali Calendar Library - کتابخانهٔ تقویم جلالی](https://github.com/ashkang/jcal)
-
-## فونت
-
-* [IranOpenFontGroup - گروه فونت آزاد ایران](https://github.com/IranOpenFontGroup)
-* [pfont - قلم آزاد فارسی](https://github.com/pfont/pfont)
-* [font-nika - قلم نیکا](https://github.com/font-store/font-nika)
-* [appa-sariicon - مجموعه‌ای از ۱۴۷ وب‌آیکون برای اپ‌موبایل و وب](https://github.com/sariina/appa-sariicon)
-* [RitaFontTester - ریتا فونت تستر ابزاری برای تسریع طراحی و توسعه فونت فارسی/عربی](https://github.com/font-store/font-nika)
-* [ویژگی‌های یک قلم فارسی استاندارد](http://saeedgnu.blog.ir/post/50)
-* [font-farbod - فونت فربد](https://github.com/font-store/font-farbod)
-
-## قالب
-
-* [bootstrap-rtl - قالب راست به چپ bootstrap 3](https://github.com/morteza/bootstrap-rtl)
-* [Bootstrap4-RTL - قالب راست به چپ bootstrap 4](https://github.com/mmdsharifi/Bootstrap4-RTL)
-* [thewhite - قالب ساده وردپرس](https://github.com/ysarbabi/thewhite)
-
-## گروه‌ها
-
-* [Tehpug - گروه کاربران پایتون تهران](http://tehpug.ir/)
-* [Tehlug - گروه کاربران گنو/لینوکس تهران](http://tehlug.org/)
-* [Karajlug - گروه کاربران لینوکس کرج](http://www.karajlug.org/)
-* [Shirazlug - گروه کاربران گنو/لینوکس شیراز](https://shirazlug.ir/)
-* [FKF - بنیاد دانش آزاد](https://wiki.lfkf.org/)
-* [Node.js Persian Community - جامعه نُد فارسی](http://nodejs.ir/)
-* [IranOnRails - ایران آن ریلز](http://iranonrails.ir/)
-* [Laratalks - جامعه لاراول ایران](http://laratalks.com/)
-
-## آموزشی
-
-* [pretotypeit - کتاب پیش‌نمونه سازی](https://github.com/yazdan/pretotypeit)
-* [Persian-HIG - آیین‌نامهٔ طرّاحی میانای کاربر گرافیکی فارسی](https://github.com/shervinafshar/Persian-HIG)
-* [Practical-Design-Patterns - مجموعه ای کامل از الگوهای طراحی](https://github.com/khajavi/Practical-Design-Patterns)
-* [DS-Book - کتاب پرسش و پاسخ داده ساختارها](https://github.com/MasoodFallahpoor/DS-Book)
-* [مجله سلام دنیا](http://salam-donya.com/)
-* [honeybee-primer - کتاب هانیبی](https://github.com/mostaphaRoudsari/honeybee-primer)
-* [ladybug-primer - کتاب لیدی‌باگ](https://github.com/mostaphaRoudsari/ladybug-primer)
-* [user-guide - کتاب هیت‌استودیو](https://github.com/heatstudio/user-guide)
-* [Python Meta Link - لیستی از منابع (فارسی) پایتون](http://gg.gg/pythonmetalink)
-
-## ادیتور
-
-* [FG42 - توزیعی برپایه ایمکس برای تازه کارها](http://fg42.lxsameer.com/)
-* [Minimalist - ویرایشگر مارک‌داون برای متون فارسی](https://github.com/brothersincode/minimalist)
-* [مارک-داون راست چین](https://github.com/dariubs/rtlmd)
-
-## سایر
-
-* [persian-words-frequency - مجموعه ای از فهرست نرخ تکرار واژه ها در متن فارسی](https://github.com/behnam/persian-words-frequency)
-* [khayyam - مجموعه رباعیات خیام در فرمت متنی yaml](https://github.com/mehdisadeghi/khayyam)
-* [StateCityZone - فهرست اسامی استان/شهر ایران به فرمت sql](https://github.com/miladr/StateCityZone)
-* [persian-stopwords - لیست کلمات ایست فارسی](https://github.com/kharazi/persian-stopwords)
-* [marhale3.github.io - پروجکت اویلر فارسی](https://github.com/marhale3/marhale3.github.io)
-* [rangebrand.ir - کد رنگ‌های رسمی برند‌های مطرح در ایران](https://github.com/IKAcc/RangeBrand)
-* [iran-cities - استان‌های ایران به‌صورت تفکیک‌شده در قالب جی‌سان](https://github.com/sijad/iran-cities)
-* [لیست کلمات فارسی](https://sourceforge.net/projects/virastyar/files/Data/1.3.1/)
-* [Sanam Style Convention - کانونشن نوشتن CSS](https://github.com/smbeiragh/sanam)
-* [iran-states-and-cities-json-and-sql-including-area-coordinations - شهرها و استان ها در فرمت های sql و json](https://github.com/pesarkhobeee/iran-states-and-cities-json-and-sql-including-area-coordinations)
-* [Iranian IT Bloggers - لیستی از خوراک‌های بلاگ‌های آی‌تی و برنامه نویسی ایرانی](https://github.com/VahidN/IranianITBloggers)
-* [محتوای ساختگی به زبان فارسی برای وردپرس](https://github.com/iazami/persian-dummy-content)
-
-درصورتی‌که برای درج لینک در این صفحه با مشکلی مواجه هستید یا پیشنهاد و انتقادی دارید در قسمت [ایشوها](https://github.com/rastikerdar/links/issues) حتما در میان بگذارید. یا اینکه با آدرس saber.rastikerdar بر روی جی‌میل نامه‌نگاری فرمایید.
-
-این صفحه در مالکیت عمومی Public Domain قرار دارد.
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D9%BE%D8%A7%DB%8C%D8%AA%D9%88%D9%86-python" class="" dir="rtl">پایتون</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%AC%D8%A7%D9%88%D8%A7%D8%B3%DA%A9%D8%B1%DB%8C%D9%BE%D8%AA-javascript" class="" dir="rtl">جاوااسکریپت</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D9%BE%DB%8C-%D8%A7%DA%86-%D9%BE%DB%8C-php" class="" dir="rtl">پی اچ پی</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%B1%D9%88%D8%A8%DB%8C-ruby" class="" dir="rtl">روبی</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%AC%D8%A7%D9%88%D8%A7-java" class="" dir="rtl">جاوا</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%DA%AF%D9%88-go" class="" dir="rtl">گو</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%A7%D9%86%D8%AF%D8%B1%D9%88%DB%8C%D8%AF-android" class="" dir="rtl">اندروید</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%B3%DB%8C-%D9%BE%D9%84%D8%A7%D8%B3-%D9%BE%D9%84%D8%A7%D8%B3-c" class="" dir="rtl">سی پلاس پلاس</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%DA%AF%D9%86%D9%88%D9%84%DB%8C%D9%86%D9%88%DA%A9%D8%B3-gnulinux" class="" dir="rtl">گنو/لینوکس</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D9%81%D9%88%D9%86%D8%AA" class="" dir="rtl">فونت</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D9%82%D8%A7%D9%84%D8%A8" class="" dir="rtl">قالب</a></li>
+<li class="" dir="rtl"><a class="" dir="rtl">گروه‌ها</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%A2%D9%85%D9%88%D8%B2%D8%B4%DB%8C" class="" dir="rtl">آموزشی</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%A7%D8%AF%DB%8C%D8%AA%D9%88%D8%B1" class="" dir="rtl">ادیتور</a></li>
+<li class="" dir="rtl"><a href="/rastikerdar/awesome-persian/blob/master/README.md#%D8%B3%D8%A7%DB%8C%D8%B1" class="" dir="rtl">سایر</a></li>
+</ul>
+</li>
+</ul>
+<h2 class="" dir="rtl">
+پایتون Python</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/aziz/PlainTasks" class="" dir="rtl">PlainTasks - پلاگین todo-list برای ویرایشگر sublime</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ilius/pyglossary" class="" dir="rtl">PyGlossary - کامل‌ترین ابزار تبدیل فایل‌های دیکشنری (گلاسری) با فرمت‌های مختلف</a></li>
+<li class="" dir="rtl"><a href="https://github.com/sobhe/hazm/" class="" dir="rtl">Hazm - کتابخانه پردازش زبان فارسی هضم در پایتون</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ilius/starcal/" class="" dir="rtl">StarCalendar - تقویم گرافیکی دوزبانه با پشتیبانی از هجری شمسی، میلادی و قمری</a></li>
+<li class="" dir="rtl"><a href="https://github.com/reza1615/Persian-Spell-checker" class="" dir="rtl">Persian-Spell-checker - غلط‌یاب فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/slashmili/python-jalali" class="" dir="rtl">jdatetime - کتابخانه تبدیل تاریخ جلالی میلادی در پایتون</a></li>
+<li class="" dir="rtl"><a href="https://github.com/itmard/persian.py" class="" dir="rtl">Persian.py - کتابخانه‌ای برای زبان فارسی در پایتون</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pylover/khayyam" class="" dir="rtl">Khayyam - کتابخانه تبدیل تاریخ جلالی میلادی خیام در پایتون</a></li>
+<li class="" dir="rtl"><a href="https://github.com/m-o-s-t-a-f-a/lilak" class="" dir="rtl">Lilak - دیکشنری غلط‌یاب فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/iraj-jelo/srtmerger" class="" dir="rtl">srtmerger - یه پروژه فان برای ترکیب کردن زیرنویس های ویدویی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/maryayi/parsnevesht" class="" dir="rtl">parsnevesht - رفع خودکار برخی اشتباهات رایج در متون فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/5j9/wikitextparser" class="" dir="rtl">wikitextparser - wikitext یک ابزار پایتونی تجزیه‌کننده</a></li>
+<li class="" dir="rtl"><a href="https://github.com/vahit/pep8-per" class="" dir="rtl">pep8-per - آموزش Python PEP8 به زبان آدمیزاد</a></li>
+<li class="" dir="rtl"><a href="https://github.com/5j9/number2farsiword" class="" dir="rtl">number2farsiword - تبدیل عدد به واژه‌فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mamal72/telegram-iranbot" class="" dir="rtl">telegram-iranbot - یک بات ساده برای تلگرام با کارکرد ترجمه انگلیسی به فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/aliva/SubtitleFixer" class="" dir="rtl">SubtitleFixer - ترمیم زیرنویس‌های فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/Honeybee" class="" dir="rtl">Honeybee - هانی‌بی - پلاگین گرس‌هاپر برای اتصال به اوپن‌استودیو، ریدینس، انرژی‌پلاس و دیزیم</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ladybug-analysis-tools/honeybeex" class="" dir="rtl">honeybeex - هانی‌بی‌اکس برای گرس ‌هاپر و داینامو </a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/ladybug" class="" dir="rtl">ladybug - لیدی‌باگ - برای طراحی فضاهای اینوایرنمنتال در گرسهاپر</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ladybug-analysis-tools/ladybug-dynamo" class="" dir="rtl">ladybug-dynamo - لیدی‌باگ برای داینامو</a></li>
+<li class="" dir="rtl"><a href="https://github.com/HydraShare/hydra-grasshopper" class="" dir="rtl">hydra-grasshopper - هیدار برای گرس هاپر</a></li>
+<li class="" dir="rtl"><a href="https://github.com/behdad/fonttools" class="" dir="rtl">fonttools - کتابخانه ای برای ویرایش فونت ها در پایتون</a></li>
+</ul>
+<h2 class="" dir="rtl">
+جاواسکریپت Javascript</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/usablica/persian.js" class="" dir="rtl">persian.js - کتابخانه‌ای برای زبان فارسی در جاوااسکرپیت</a></li>
+<li class="" dir="rtl"><a href="https://github.com/habibpour/rial.js" class="" dir="rtl">rial.js - کتابخانه‌ای برای فرمت نرخ و پول در جاوااسکریپت</a></li>
+<li class="" dir="rtl"><a href="https://github.com/nainemom/sentence-info" class="" dir="rtl">sentence-info - نمایش اطلاعات نگارشی جمله فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arashmilani/PersianDocumentNumberInputFix" class="" dir="rtl">کتابخانه تصحیح ورود عدد فارسی در جاوااسکریپت jquery</a></li>
+<li class="" dir="rtl"><a href="http://tmtheme-editor.herokuapp.com/" class="" dir="rtl">tmTheme-Editor - ویرایشگر طرح رنگ برای editorها</a></li>
+<li class="" dir="rtl"><a href="https://github.com/reza1615/PersianOcr" class="" dir="rtl">PersianOcr - تشخیص کامپیوتری متن‌های نوشته‌شده به زبان فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/habibpour/simple-html5-game" class="" dir="rtl">simple-html5-game - یک بازی ساده HTML5</a></li>
+<li class="" dir="rtl"><a href="https://github.com/omid/Persian-Calendar-for-Gnome-Shell" class="" dir="rtl">Persian-Calendar-for-Gnome-Shell - تاریخ/تقویم فارسی برای گنوم</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mehdisadeghi/SaaghiBot" class="" dir="rtl">SaaghiBot - بات اشعار خیام برای تلگرام</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mohebifar/angular-persian" class="" dir="rtl">angular-persian - ابزارهای فارسی برای آنگولار</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mohebifar/lebab" class="" dir="rtl">lebab - تبدیل کد ES5 به ES6</a></li>
+<li class="" dir="rtl"><a href="https://github.com/babakhani/PersianDate" class="" dir="rtl">PersianDate - سیستم parsing, validating, manipulating و formatting تاریخ فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/babakhani/pwt.datepicker" class="" dir="rtl">pwt.datepicker - ابزار انتخاب‌گر تاریخ</a></li>
+<li class="" dir="rtl"><a href="https://github.com/AminRahimi/angular-bootstrap-persian-datepicker" class="" dir="rtl">Angular Bootstrap Persian Datepicker - تقویم شمسی آنگولار</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mousavian/bootstrap-jalali-datepicker" class="" dir="rtl">Twitter Bootstrap Jalali Datepicker - تقویم شمسی برای توییتر بوت استرپ</a></li>
+<li class="" dir="rtl"><a href="https://github.com/sobhe/moratab" class="" dir="rtl">moratab - تسهیل ویرایش متون markdown</a></li>
+<li class="" dir="rtl"><a href="https://github.com/kharazi/moujez" class="" dir="rtl">moujez - خلاصه‌سازی متن</a></li>
+<li class="" dir="rtl"><a href="https://github.com/imasood/nbpersian" class="" dir="rtl">nbpersian - کتاب Node.js برای مبتدی‌ها</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mohebifar/chemozart" class="" dir="rtl">chemozart - مدل‌ساز و ویرایشگر سه بعدی مولکولی مبتنی بر وب</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mamal72/telegram-github-search-bot" class="" dir="rtl">telegram-github-search-bot - بات جستجوی گیت‌هاب برای تلگرام</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mohebifar/react-persian" class="" dir="rtl">react-persian - مجموعه‌ای از کامپوننت های React برای زبان فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mohebifar/react-persian-datepicker" class="" dir="rtl">react-persian-datepicker - انتخابگر تاریخ فارسی برای React</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mamal72/react-github" class="" dir="rtl">react-github - یک مجموعه از کامپوننت های React برای گیت‌هاب</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mamal72/electron-jalali-calendar" class="" dir="rtl">electron-jalali-calendar - منوبار تقویم جلالی ساخته‌شده با Electron و React</a></li>
+<li class="" dir="rtl"><a href="https://github.com/jalaali/jalaali-js" class="" dir="rtl">jalaali-js - تبدیل تاریخ شمسی به میلادی و بالعکس</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arastu/iran" class="" dir="rtl">Iran - Administrative divisions of Iran in json and xml formats - تقسیمات کشوری ایران با فرمت جی‌سان و ایکس ام ال</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/epwmap" class="" dir="rtl">epwmap - ای‌پی‌دابلیو مپ - نقشه فایل های آب و هوای وزارت انرژی آمریکا بر روی نقشه جهان</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/SettlementEmerge" class="" dir="rtl">SettlementEmerge - ستلمنت‌امرج - نقشه ای برای تصمیم گیری در جهت احداث های زیست محیطی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/juvee/virastar/" class="" dir="rtl">Virastar - نوشته‌های فارسی شما را ویرایش می‌کند</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ehsandanesh/fullcalendar/" class="" dir="rtl">fullcalendar - تقویم تمام صفحه برای مدیریت رویداده‌ها با کشیدن و رهاکردن</a></li>
+</ul>
+<h2 class="" dir="rtl">
+پی اچ پی PHP</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/sallar/jDateTime" class="" dir="rtl">jDateTime - کتابخانه تبدیل تاریخ جلالی میلادی در php</a></li>
+<li class="" dir="rtl"><a href="https://github.com/morilog/jalali" class="" dir="rtl">jalali - تسهیل کار با تاریخ ایرانی شمسی جلالی در برنامه های لاراول 5</a></li>
+<li class="" dir="rtl"><a href="https://github.com/laratalks/payment-gateways" class="" dir="rtl">payment-gateways - بسته پردازش درگاه برای سیستم شتاب ایران</a></li>
+<li class="" dir="rtl"><a href="https://github.com/PoolPort/PoolPort" class="" dir="rtl">پکیج کار با درگاههای بانکی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/iazami/popcorn" class="" dir="rtl">popcorn - یک API برای دریافت اطلاعات فیلم و سریال</a></li>
+</ul>
+<h2 class="" dir="rtl">
+روبی Ruby</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/aziz/jalalidate" class="" dir="rtl">jalalidate - کتابخانه تبدیل تاریخ جلالی میلادی در روبی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/BHRC/openstudio-standards" class="" dir="rtl">openstudio-standards - مبحث‌۱۹ در اپن استودیو - استاندارد های انرژی ایران برای اوپن‌استودیو</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/erect" class="" dir="rtl">erect - ارکت - نانو بیلد سیستم</a></li>
+</ul>
+<h2 class="" dir="rtl">
+جاوا Java</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/abbashosseini/PersianDT" class="" dir="rtl">PersianDT - کتابخانه تاریخ شمسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/azinazadi/GraphLab" class="" dir="rtl">GraphLab - گرافلب شریف - استودیو تئوری گراف</a></li>
+</ul>
+<h2 class="" dir="rtl">
+گو GO</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/sijad/srtfixer" class="" dir="rtl">srtfixer - ترمیم زیرنویس‌های فارسی</a></li>
+</ul>
+<h2 class="" dir="rtl">
+اندروید Android</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/ebraminio/DroidPersianCalendar" class="" dir="rtl">DroidPersianCalendar - برنامه تقویم فارسی اندروید</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alibehzadian/PersianDatePicker" class="" dir="rtl">PersianDatePicker - کتابخانه انتخاب‌گر تاریخ فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/MasoodFallahpoor/TehranBrt" class="" dir="rtl">TehranBrt - برنامه نمایش مسیرها و ایستگاه‌های بی آر تی تهران</a></li>
+<li class="" dir="rtl"><a href="https://github.com/MasoodFallahpoor/InfoCenter" class="" dir="rtl">InfoCenter - برنامه نمایش اطلاعات سخت‌افزاری گوشی/تبلت اندرویدی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mohamad-amin/PersianMaterialDateTimePicker" class="" dir="rtl">PersianMaterialDateTimePicker - کتابخانه انتخاب‌گر تاریخ فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alirezaafkar/SunDatePicker" class="" dir="rtl">SunDatePicker - کتابخانه انتخاب‌گر تاریخ فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/NileGroup/Meikade" class="" dir="rtl">Persian poem application - مجموعهٔ شعر فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/farsitel/" class="" dir="rtl">farsitel - فارسیتل - اندروید فارسی</a></li>
+</ul>
+<h2 class="" dir="rtl">
+سی پلاس پلاس C++</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/m-o-s-t-a-f-a/dana" class="" dir="rtl">Dana - ابزاری برای توسعه دانش به روش یادگیری Spaced Repetition</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/Butterfly" class="" dir="rtl">Butterfly - باترفلای - کانکشن گرسه‌هاپر به اوپن‌فوم</a></li>
+<li class="" dir="rtl"><a href="https://github.com/keyvank/tracy" class="" dir="rtl">tracy - تریسی - موتور گرافیک سه بعدی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/behdad/harfbuzz" class="" dir="rtl">harfbuzz - کتابخانه text shaping</a></li>
+</ul>
+<h2 class="" dir="rtl">
+سی شارپ C</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/HydraShare/hydra-dynamo" class="" dir="rtl">hydra-dynamo - هیدار داینامو - برای انتشار مدل های داینامو در وب</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pabloengine/pablo" class="" dir="rtl">pablo - پابلو - موتور صفحه بندی و لیات </a></li>
+<li class="" dir="rtl"><a href="https://github.com/karyfoundation/framework-base" class="" dir="rtl">framework-base - فریمورک کاری - فریم ورک ویرایش، قالب بندی و شکل دهی به متون</a></li>
+<li class="" dir="rtl"><a href="https://github.com/karyfoundation/intactus" class="" dir="rtl">intactus - اینتکتوس - کتابخانه تولید نوتیشن ریاضی و چارت با استفاده از متن</a></li>
+<li class="" dir="rtl"><a href="https://github.com/keyvank/i3dml" class="" dir="rtl">i3dml - آی‌تری‌دی‌ام - تریسی در دات نت</a></li>
+<li class="" dir="rtl"><a href="https://github.com/Behrooz-Amoozad/BD2" class="" dir="rtl">BD2 - بی‌دی‌۲ - موتور دیتابیس توضیع شده</a></li>
+<li class="" dir="rtl"><a href="https://github.com/karyfoundation/numerica" class="" dir="rtl">numerica - نومریکا - تایپ عددی با ظرفیت دلخواه</a></li>
+<li class="" dir="rtl"><a href="https://github.com/karyfoundation/calculat" class="" dir="rtl">calculat -  NCalcکلکولات - نسخه بهتر شده کتابخانه</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/series" class="" dir="rtl">series - سریز - یک بازی ترمینالی برای حدث زدن فرمول دنباله ها</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/loc" class="" dir="rtl">loc - لک - خط شمار تحت فریمورک کاری</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/note" class="" dir="rtl">note - نوت - برنامه یاداشت تحت فریمورک کاری</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/equer" class="" dir="rtl">equer - ایکوئر: تبدیل کننده فرمول به اسکریپت</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/textfliper" class="" dir="rtl">textfliper -  تکست فیلپر - برای دوباره فارسی کردن نوشته های کپی شده از پی دی اف های ادوبی </a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/binominor" class="" dir="rtl">binominor - بینومینال - گسترش دهنده بسته نیوتونی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/RDF-Co/PersianNumericConverter" class="" dir="rtl">PersianNumericConverter - مبدل عدد به متن فارسی و برعکس</a></li>
+<li class="" dir="rtl"><a href="https://github.com/salarcode/Bois" class="" dir="rtl">Bois - Binary Object Serializer تبدیل آبجکت ها به باینری فشرده</a></li>
+</ul>
+<h2 class="" dir="rtl">
+آبجکتیو-سی Objective-C</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/kkiani/Uninstaller" class="" dir="rtl">Uninstaller - آن‌اینستالر - برنامه ای برای مدیریت برنامه های مک</a></li>
+</ul>
+<h2 class="" dir="rtl">
+اپل‌اسکریپت AppleScript</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/pmkary/osx-term-icon" class="" dir="rtl">osx-term-icon - آیکون برای برنامه های شل</a></li>
+</ul>
+<h2 class="" dir="rtl">
+تایپ اسکریپت TypeScript</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/karyfoundation/comment" class="" dir="rtl">comment - کامنت - جنریتور کامنت های کی-اف-سی-اس</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pmkary/V" class="" dir="rtl">V - وی - ابزاری برای تنظیم ارتفاع دیو های یک ردیف</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alitaheri/react-mixout" class="" dir="rtl">react-mixout - میکس آوت - میکیسنگ با اولویت بالاتر</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alitaheri/isomorphic-vm" class="" dir="rtl">isomorphic-vm - ایزومورفیک وی ام - دسترسی به نود جی اس از مرورگر</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alitaheri/react-stated" class="" dir="rtl">react-stated - ری‌اکت استیتد - برای انتقال منطق کامپوننت ها به بیرون آن ها</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alitaheri/react-warpgate" class="" dir="rtl">react-warpgate - ری‌اکت رپ‌گیت - ابزاری برای پیمایش اثربری ری‌اکت</a></li>
+<li class="" dir="rtl"><a href="https://github.com/alitaheri/react-memo" class="" dir="rtl">react-memo - ری‌اکت ممو</a></li>
+</ul>
+<h2 class="" dir="rtl">
+ارندل arendelle</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/arendelle/marker.js" class="" dir="rtl">marker.js - مارکر.جی‌اس - هایلایتر وب ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/marker.js" class="" dir="rtl">marker.js - مارکر.جی‌اس - هایلایتر وب ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/kai" class="" dir="rtl">kai - کای‌ - پکج ارندل برای اتم</a></li>
+<li class="" dir="rtl"><a href="https://github.com/sinabakh/arendelle-js-core" class="" dir="rtl">arendelle-js-core - کامپایلر ارندل به جاوا اسکریپت برای ارندل ۳</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/gerda" class="" dir="rtl">gerda - جردا - اینتلی سنس برای ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/sketchup-grid-importer" class="" dir="rtl">sketchup-grid-importer - ایمپورتر گرید ارندل برای اسکپ‌آپ</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/arcco" class="" dir="rtl">arcco - آرکو - داکیومنشن جنریتور ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/arcade" class="" dir="rtl">arcade - آرکید - اینترپرتر ارندل تا نسخه ۱.۶</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/cliff" class="" dir="rtl">cliff - کلیف - فرمتر کد ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/gothi" class="" dir="rtl">gothi - گاثی - تولید کننده متن برای ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/marker" class="" dir="rtl">marker - مارکر - هایلایتر وب ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/sitron" class="" dir="rtl">sitron - سیترون - مفسر ارندل ۲.۱۴</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/book" class="" dir="rtl">book - کتاب زبان ارندل</a></li>
+<li class="" dir="rtl"><a href="https://github.com/arendelle/swifty" class="" dir="rtl">swifty - سویفتی - مفسر سویفت ۲.۱۴</a></li>
+</ul>
+<h2 class="" dir="rtl">
+گنو/لینوکس GNU/Linux</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/jadijadi/linuxandlife" class="" dir="rtl">linuxandlife - کتاب راهنمای لینوکس و زندگی</a></li>
+<li class="" dir="rtl"><a href="http://wiki.linuxreview.ir/Shell-scripting-tutorial" class="" dir="rtl">راهنمای شِل اسکریپتینگ (برنامه‌نویسی خط فرمان لینوکس)</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ashkang/jcal" class="" dir="rtl">Jalali Calendar Library - کتابخانهٔ تقویم جلالی</a></li>
+</ul>
+<h2 class="" dir="rtl">
+فونت</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/IranOpenFontGroup" class="" dir="rtl">IranOpenFontGroup - گروه فونت آزاد ایران</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pfont/pfont" class="" dir="rtl">pfont - قلم آزاد فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/font-store/font-nika" class="" dir="rtl">font-nika - قلم نیکا</a></li>
+<li class="" dir="rtl"><a href="https://github.com/sariina/appa-sariicon" class="" dir="rtl">appa-sariicon - مجموعه‌ای از ۱۴۷ وب‌آیکون برای اپ‌موبایل و وب</a></li>
+<li class="" dir="rtl"><a href="https://github.com/font-store/font-nika" class="" dir="rtl">RitaFontTester - ریتا فونت تستر ابزاری برای تسریع طراحی و توسعه فونت فارسی/عربی</a></li>
+<li class="" dir="rtl"><a href="http://saeedgnu.blog.ir/post/50" class="" dir="rtl">ویژگی‌های یک قلم فارسی استاندارد</a></li>
+<li class="" dir="rtl"><a href="https://github.com/font-store/font-farbod" class="" dir="rtl">font-farbod - فونت فربد</a></li>
+</ul>
+<h2 class="" dir="rtl">
+قالب</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/morteza/bootstrap-rtl" class="" dir="rtl">bootstrap-rtl - قالب راست به چپ bootstrap 3</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mmdsharifi/Bootstrap4-RTL" class="" dir="rtl">Bootstrap4-RTL - قالب راست به چپ bootstrap 4</a></li>
+<li class="" dir="rtl"><a href="https://github.com/ysarbabi/thewhite" class="" dir="rtl">thewhite - قالب ساده وردپرس</a></li>
+</ul>
+<h2 class="" dir="rtl">
+گروه‌ها</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="http://tehpug.ir/" class="" dir="rtl">Tehpug - گروه کاربران پایتون تهران</a></li>
+<li class="" dir="rtl"><a href="http://tehlug.org/" class="" dir="rtl">Tehlug - گروه کاربران گنو/لینوکس تهران</a></li>
+<li class="" dir="rtl"><a href="http://www.karajlug.org/" class="" dir="rtl">Karajlug - گروه کاربران لینوکس کرج</a></li>
+<li class="" dir="rtl"><a href="https://shirazlug.ir/" class="" dir="rtl">Shirazlug - گروه کاربران گنو/لینوکس شیراز</a></li>
+<li class="" dir="rtl"><a href="https://wiki.lfkf.org/" class="" dir="rtl">FKF - بنیاد دانش آزاد</a></li>
+<li class="" dir="rtl"><a href="http://nodejs.ir/" class="" dir="rtl">Node.js Persian Community - جامعه نُد فارسی</a></li>
+<li class="" dir="rtl"><a href="http://iranonrails.ir/" class="" dir="rtl">IranOnRails - ایران آن ریلز</a></li>
+<li class="" dir="rtl"><a href="http://laratalks.com/" class="" dir="rtl">Laratalks - جامعه لاراول ایران</a></li>
+</ul>
+<h2 class="" dir="rtl">
+آموزشی</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/yazdan/pretotypeit" class="" dir="rtl">pretotypeit - کتاب پیش‌نمونه سازی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/shervinafshar/Persian-HIG" class="" dir="rtl">Persian-HIG - آیین‌نامهٔ طرّاحی میانای کاربر گرافیکی فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/khajavi/Practical-Design-Patterns" class="" dir="rtl">Practical-Design-Patterns - مجموعه ای کامل از الگوهای طراحی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/MasoodFallahpoor/DS-Book" class="" dir="rtl">DS-Book - کتاب پرسش و پاسخ داده ساختارها</a></li>
+<li class="" dir="rtl"><a href="http://salam-donya.com/" class="" dir="rtl">مجله سلام دنیا</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/honeybee-primer" class="" dir="rtl">honeybee-primer - کتاب هانیبی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mostaphaRoudsari/ladybug-primer" class="" dir="rtl">ladybug-primer - کتاب لیدی‌باگ</a></li>
+<li class="" dir="rtl"><a href="https://github.com/heatstudio/user-guide" class="" dir="rtl">user-guide - کتاب هیت‌استودیو</a></li>
+<li class="" dir="rtl"><a href="http://gg.gg/pythonmetalink" class="" dir="rtl">Python Meta Link - لیستی از منابع (فارسی) پایتون</a></li>
+</ul>
+<h2 class="" dir="rtl">
+ادیتور</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="http://fg42.lxsameer.com/" class="" dir="rtl">FG42 - توزیعی برپایه ایمکس برای تازه کارها</a></li>
+<li class="" dir="rtl"><a href="https://github.com/brothersincode/minimalist" class="" dir="rtl">Minimalist - ویرایشگر مارک‌داون برای متون فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/dariubs/rtlmd" class="" dir="rtl">مارک-داون راست چین</a></li>
+</ul>
+<h2 class="" dir="rtl">
+سایر</h2>
+<ul class="" dir="rtl">
+<li class="" dir="rtl"><a href="https://github.com/behnam/persian-words-frequency" class="" dir="rtl">persian-words-frequency - مجموعه ای از فهرست نرخ تکرار واژه ها در متن فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/mehdisadeghi/khayyam" class="" dir="rtl">khayyam - مجموعه رباعیات خیام در فرمت متنی yaml</a></li>
+<li class="" dir="rtl"><a href="https://github.com/miladr/StateCityZone" class="" dir="rtl">StateCityZone - فهرست اسامی استان/شهر ایران به فرمت sql</a></li>
+<li class="" dir="rtl"><a href="https://github.com/kharazi/persian-stopwords" class="" dir="rtl">persian-stopwords - لیست کلمات ایست فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/marhale3/marhale3.github.io" class="" dir="rtl">marhale3.github.io - پروجکت اویلر فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/IKAcc/RangeBrand" class="" dir="rtl">rangebrand.ir - کد رنگ‌های رسمی برند‌های مطرح در ایران</a></li>
+<li class="" dir="rtl"><a href="https://github.com/sijad/iran-cities" class="" dir="rtl">iran-cities - استان‌های ایران به‌صورت تفکیک‌شده در قالب جی‌سان</a></li>
+<li class="" dir="rtl"><a href="https://sourceforge.net/projects/virastyar/files/Data/1.3.1/" class="" dir="rtl">لیست کلمات فارسی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/smbeiragh/sanam" class="" dir="rtl">Sanam Style Convention - کانونشن نوشتن CSS</a></li>
+<li class="" dir="rtl"><a href="https://github.com/pesarkhobeee/iran-states-and-cities-json-and-sql-including-area-coordinations" class="" dir="rtl">iran-states-and-cities-json-and-sql-including-area-coordinations - شهرها و استان ها در فرمت های sql و json</a></li>
+<li class="" dir="rtl"><a href="https://github.com/VahidN/IranianITBloggers" class="" dir="rtl">Iranian IT Bloggers - لیستی از خوراک‌های بلاگ‌های آی‌تی و برنامه نویسی ایرانی</a></li>
+<li class="" dir="rtl"><a href="https://github.com/iazami/persian-dummy-content" class="" dir="rtl">محتوای ساختگی به زبان فارسی برای وردپرس</a></li>
+</ul>
+<p class="" dir="rtl">درصورتی‌که برای درج لینک در این صفحه با مشکلی مواجه هستید یا پیشنهاد و انتقادی دارید در قسمت <a href="https://github.com/rastikerdar/links/issues" class="" dir="rtl">ایشوها</a> حتما در میان بگذارید. یا اینکه با آدرس saber.rastikerdar بر روی جی‌میل نامه‌نگاری فرمایید.</p>
+<p class="" dir="rtl">این صفحه در مالکیت عمومی Public Domain قرار دارد.</p>
+</div>


### PR DESCRIPTION


This will make GitHub render all of the text from right to left. 

All I did was to write a quick script to do this. In case you want to do the same for your other docs:

```js
// $0 is the wrapper around markdown rendered to HTML by GitHub. 
for (const el of $0.querySelectorAll('*')) { 
  if (el.classList.contains('anchor')) { el.parentElement.removeChild(el) }
  el.className = '';
  el.dir = 'rtl'
}
```